### PR TITLE
Fixed warnings in npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "repository" : {
    "type" : "git",
    "url"  : "git:///github.com/electronic-shepherd/electronic-shepherd.git"
-  }
+  },
 
   "private" : true,
 
@@ -35,7 +35,6 @@
     "@angular/platform-browser": "2.0.0-rc.1",
     "@angular/platform-browser-dynamic": "2.0.0-rc.1",
     "@angular/router": "2.0.0-rc.1",
-    "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.3",
     "rxjs": "5.0.0-beta.6",
     "systemjs": "0.19.26",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   
   "repository" : {
    "type" : "git",
-   "url"  : "https:///github.com/electronic-shepherd/electronic-shepherd.git"
+   "url"  : "https://github.com/electronic-shepherd/electronic-shepherd.git"
   },
 
   "private" : true,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   
   "repository" : {
    "type" : "git",
-   "url"  : "git:///github.com/electronic-shepherd/electronic-shepherd.git"
+   "url"  : "https:///github.com/electronic-shepherd/electronic-shepherd.git"
   },
 
   "private" : true,

--- a/package.json
+++ b/package.json
@@ -10,9 +10,17 @@
   },
   "license": "Apache-2.0",
   "author" : "electronic-shepherd",
+  
+  "repository" : {
+   "type" : "git",
+   "url"  : "git:///github.com/electronic-shepherd/electronic-shepherd.git"
+  }
+
+  "private" : true,
+
   "devDependencies": {
     "electron-prebuilt": "^1.2.0",
-    "es6-shim": "^0.34.0",
+    "es6-shim": "^0.35.0",
     "ts-loader": "^0.8.2",
     "typescript": "^1.8.10",
     "typings": "^0.8.1",


### PR DESCRIPTION
### What is this PR for?
Fixing npm install warnings

* Changed dependencies of es6shim for development to the same as release
* Added a repository entry into package.json for our official repo
* Added the key private to package.json to prevent accidental publish to npm

### What type of PR is it?
Improvement

### How to test

* Pull changes from branch into local repository
* `npm install`

The warnings shouldn't be there anymore

